### PR TITLE
fixed duplicated class name issue

### DIFF
--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -143,7 +143,7 @@ function App() {
                               station={selectedStation} stationChange={handleSelectedStationChange} upcomingOnlyValue={upcomingOnly} upcomingOnlyChange={handleUpcomingOnlyChange}
                       />
                   </div>
-                  <div className='train-list-container'>
+                  <div className='app-train-list-container'>
                       <TrainList className = 'TrainList' trains={currentTrains} handleTrainClick={handleTrainClick}/>
                   </div>
                   <div className='map-container'>

--- a/train-tracker/src/styles/App.css
+++ b/train-tracker/src/styles/App.css
@@ -50,7 +50,7 @@
   border-radius: 8px;
 }
 
-.train-list-container {
+.app-train-list-container {
   width: 25%;
   height: 80vh;
   padding: 1rem;
@@ -79,7 +79,7 @@
     flex-direction: column;
   }
 
-  .search-container, .train-list-container, .map-container {
+  .search-container, .app-train-list-container, .map-container {
     width: 100%;
     height: auto;
     margin-bottom: 1rem;


### PR DESCRIPTION
After merging the last 2 PRs, there was a duplicated class name causing issues with the train list component sizing.

This is what the app looks like after the merges and this fix:

![image](https://github.com/user-attachments/assets/580297b0-3089-4095-87ee-22233af10a3b)

(On a large screen, there are styling/sizing issues on a smaller one)