### PR TITLE
User geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 # How to contribute
 
-Follow this [project board](https://github.com/orgs/cis3296f24/projects/105/views/1) to know the latest status of the project.
+Follow this [project board](https://github.com/orgs/cis3296f24/projects/105) to know the latest status of the project.
 ## How to build
 
 Use this [github repository](https://github.com/cis3296f24/TrainTracker/)
@@ -55,3 +55,5 @@ Use this [github repository](https://github.com/cis3296f24/TrainTracker/)
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 The train favicon was downloaded from [Train icons created by Smashicons - Flaticon](https://www.flaticon.com/free-icon/train_2855692).
+
+The routes GeoJSON data was downloaded from [The US Department of Transportation](https://data-usdot.opendata.arcgis.com/datasets/usdot::amtrak-routes/explore?location=38%2C-79%2C6.60).

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -14,7 +14,8 @@ function App() {
     const api = new Amtrak.APIInstance();
 
     const [userLocation, setUserLocation] = useState(null);
-    const [selectedStation, setselectedStation] = useState("");
+    const [selectedStation, setSelectedStation] = useState("");
+    const [selectedRoute, setSelectedRoute] = useState("");
 
     const [allTrains, setAllTrains] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
@@ -35,7 +36,7 @@ function App() {
             navigator.geolocation.getCurrentPosition((pos)=>{
                 setUserLocation(pos);
                 if (allStations.length > 0 && pos){
-                    setselectedStation(getClosestStation(allStations, pos).stationCode);
+                    setSelectedStation(getClosestStation(allStations, pos).stationCode);
                 }
             }, 
             (error) => console.log('error' + error));
@@ -63,6 +64,16 @@ function App() {
         )
     }
   
+    const homePage = <Home
+        allTrains={allTrains}
+        allRoutes={allRoutes}
+        allStations={allStations}
+        userLocation={userLocation}
+        selectedStation={selectedStation}
+        setSelectedStation={setSelectedStation}
+        selectedRoute={selectedRoute}
+        setSelectedRoute={setSelectedRoute}
+    />;
     
   return (
     <HashRouter>
@@ -80,22 +91,8 @@ function App() {
               
           <div className='content'>
                 <Routes>
-                    <Route path="/" element={<Home
-                        allTrains={allTrains}
-                        allRoutes={allRoutes}
-                        allStations={allStations}
-                        userLocation={userLocation}
-                        selectedStation={selectedStation}
-                        setSelectedStation={setselectedStation}
-                    />}/>
-                    <Route path="/home" element={<Home
-                        allTrains={allTrains}
-                        allRoutes={allRoutes}
-                        allStations={allStations}
-                        userLocation={userLocation}
-                        selectedStation={selectedStation}
-                        setSelectedStation={setselectedStation}
-                    />}/>
+                    <Route path="/" element={homePage}/>
+                    <Route path="/home" element={homePage}/>
                     <Route path="/train/:trainInfo" element={<TrainPage/>}/>
                 </Routes>
               </div> 

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -7,11 +7,14 @@ import { useNavigate, Link, Routes, Route, HashRouter } from 'react-router-dom';
 import Home from './Home';
 import TrainPage from './TrainPage';
 
+import { getClosestStation } from './functionality/app';
+
 function App() {
     // load api data
     const api = new Amtrak.APIInstance();
 
     const [userLocation, setUserLocation] = useState(null);
+    const [selectedStation, setselectedStation] = useState("");
 
     const [allTrains, setAllTrains] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
@@ -29,15 +32,17 @@ function App() {
 
     useEffect(() => {
         if (navigator.geolocation) {
-            navigator.geolocation.getCurrentPosition(recordLocation, 
+            navigator.geolocation.getCurrentPosition((pos)=>{
+                setUserLocation(pos);
+                if (allStations.length > 0 && pos){
+                    setselectedStation(getClosestStation(allStations, pos).stationCode);
+                }
+            }, 
             (error) => console.log('error' + error));
         }
-        console.log(userLocation);
+        
     }, [allStations]);
 
-    function recordLocation(position) {
-        setUserLocation(position);
-    }
 
     function TrainForm(){
         const [selectedNumber, setSelectedNumber] = useState("");
@@ -80,12 +85,16 @@ function App() {
                         allRoutes={allRoutes}
                         allStations={allStations}
                         userLocation={userLocation}
+                        selectedStation={selectedStation}
+                        setSelectedStation={setselectedStation}
                     />}/>
                     <Route path="/home" element={<Home
                         allTrains={allTrains}
                         allRoutes={allRoutes}
                         allStations={allStations}
                         userLocation={userLocation}
+                        selectedStation={selectedStation}
+                        setSelectedStation={setselectedStation}
                     />}/>
                     <Route path="/train/:trainInfo" element={<TrainPage/>}/>
                 </Routes>

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -11,6 +11,8 @@ function App() {
     // load api data
     const api = new Amtrak.APIInstance();
 
+    const [userLocation, setUserLocation] = useState(null);
+
     const [allTrains, setAllTrains] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
     const [allStations, setAllStations] = useState([]);
@@ -22,7 +24,20 @@ function App() {
             setAllStations(this.stations);
         }
         api.update();
+
     },[]);
+
+    useEffect(() => {
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(recordLocation, 
+            (error) => console.log('error' + error));
+        }
+        console.log(userLocation);
+    }, [allStations]);
+
+    function recordLocation(position) {
+        setUserLocation(position);
+    }
 
     function TrainForm(){
         const [selectedNumber, setSelectedNumber] = useState("");
@@ -64,11 +79,13 @@ function App() {
                         allTrains={allTrains}
                         allRoutes={allRoutes}
                         allStations={allStations}
+                        userLocation={userLocation}
                     />}/>
                     <Route path="/home" element={<Home
                         allTrains={allTrains}
                         allRoutes={allRoutes}
                         allStations={allStations}
+                        userLocation={userLocation}
                     />}/>
                     <Route path="/train/:trainInfo" element={<TrainPage/>}/>
                 </Routes>

--- a/train-tracker/src/Home.js
+++ b/train-tracker/src/Home.js
@@ -12,7 +12,7 @@ import {filterTrains} from './functionality/app.js'
 
 import { IoClose } from "react-icons/io5";
 
-function Home({allTrains, allRoutes, allStations, userLocation, selectedStation, setSelectedStation}){
+function Home({allTrains, allRoutes, allStations, userLocation, selectedStation, setSelectedStation, selectedRoute, setSelectedRoute}){
     // sorted trains
     const [currentTrains, setCurrentTrains] = useState([]);
 
@@ -66,6 +66,8 @@ function Home({allTrains, allRoutes, allStations, userLocation, selectedStation,
                 searchFun = {searchTrains}
                 setSelectedStation={setSelectedStation}
                 selectedStation={selectedStation}
+                selectedRoute={selectedRoute}
+                setSelectedRoute={setSelectedRoute}
               />
               </div>
               <div className='app-train-list-container'>
@@ -79,6 +81,7 @@ function Home({allTrains, allRoutes, allStations, userLocation, selectedStation,
                     trains={currentTrains}
                     userLocation={userLocation}
                     selectedStation={convertStationCodeToStation(allStations, selectedStation)}
+                    selectedRoute={selectedRoute}
                 />
               </div>
               <div>

--- a/train-tracker/src/Home.js
+++ b/train-tracker/src/Home.js
@@ -1,5 +1,7 @@
 import './styles/Home.css';
-import React, {useState, useEffect} from 'react'
+import React, {useState} from 'react'
+
+import {convertStationCodeToStation} from './functionality/app.js';
 
 import Map from './Map';
 import TrainList from './TrainList';
@@ -10,7 +12,7 @@ import {filterTrains} from './functionality/app.js'
 
 import { IoClose } from "react-icons/io5";
 
-function Home({allTrains, allRoutes, allStations, userLocation}){
+function Home({allTrains, allRoutes, allStations, userLocation, selectedStation, setSelectedStation}){
     // sorted trains
     const [currentTrains, setCurrentTrains] = useState([]);
 
@@ -36,7 +38,7 @@ function Home({allTrains, allRoutes, allStations, userLocation}){
         let renderedRoutes = allRoutes.sort((a, b) => (a.Name).localeCompare(b.Name)).map(route => {
             return <option value={route.Name} key={route.Name}>{route.Name}</option>
         });
-        renderedRoutes.unshift(<option value={""} key={""}>All routes</option>);
+        renderedRoutes.unshift(<option value={""} key={""}></option>);
         return renderedRoutes;
     }
 
@@ -55,7 +57,6 @@ function Home({allTrains, allRoutes, allStations, userLocation}){
     </div>);
 
     const modal = <TrainPopup onClose={handleModalClose} actionBar={closeButton} train={selectedTrain}/>
-
     return (
         <div className='home-page'>
             <div className='search-container'>
@@ -63,6 +64,8 @@ function Home({allTrains, allRoutes, allStations, userLocation}){
                 routes = {getRouteOptions()}
                 stations = {getStationOptions()}
                 searchFun = {searchTrains}
+                setSelectedStation={setSelectedStation}
+                selectedStation={selectedStation}
               />
               </div>
               <div className='app-train-list-container'>
@@ -75,6 +78,7 @@ function Home({allTrains, allRoutes, allStations, userLocation}){
                 <Map className = 'Map' 
                     trains={currentTrains}
                     userLocation={userLocation}
+                    selectedStation={convertStationCodeToStation(allStations, selectedStation)}
                 />
               </div>
               <div>

--- a/train-tracker/src/Home.js
+++ b/train-tracker/src/Home.js
@@ -10,9 +10,7 @@ import {filterTrains} from './functionality/app.js'
 
 import { IoClose } from "react-icons/io5";
 
-function Home({
-    allTrains, allRoutes, allStations
-}){
+function Home({allTrains, allRoutes, allStations, userLocation}){
     // sorted trains
     const [currentTrains, setCurrentTrains] = useState([]);
 
@@ -76,6 +74,7 @@ function Home({
               <div className='map-container'>
                 <Map className = 'Map' 
                     trains={currentTrains}
+                    userLocation={userLocation}
                 />
               </div>
               <div>

--- a/train-tracker/src/Map.js
+++ b/train-tracker/src/Map.js
@@ -4,6 +4,7 @@ import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import { IoTrainOutline } from "react-icons/io5";
 import { FaLocationDot } from "react-icons/fa6";
+import { FaBuildingUser } from "react-icons/fa6";
 import { renderToString } from "react-dom/server";
 import './styles/Map.css';
 
@@ -20,7 +21,7 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
-const Map = ({trains, userLocation}) => {
+const Map = ({trains, userLocation, selectedStation}) => {
     const [railLines, setRailLines] = useState(null);
     const [stations, setStations] = useState(null);
     // const [trains, setTrains] = useState([]);
@@ -99,6 +100,12 @@ const Map = ({trains, userLocation}) => {
         </div>
     );
 
+    const SelectedStationIcon = () => (
+        <div className="custom-icon-container" style={{ color: "black" }}>
+            <FaBuildingUser size={20} />
+        </div>
+    );
+
     function UserLocationMarker(){
         if (userLocation){
             return (
@@ -114,6 +121,27 @@ const Map = ({trains, userLocation}) => {
 
                     <Popup>
                         <p>Your location.</p>
+                    </Popup>
+                </Marker>)
+        }
+    }
+
+    function SelectedStationMarker(){
+        if (selectedStation){
+            return (
+                <Marker
+                    key={'selectedStation'}
+                    position={[selectedStation.lat, selectedStation.lon]}
+                    icon={L.divIcon({
+                        html: renderToString(<SelectedStationIcon />),
+                        className: 'custom-icon',
+                        iconSize: [30, 30],
+                        iconAnchor: [15, 15]
+                    })}>
+
+                    <Popup>
+                        <strong>Selected Station</strong>
+                        <p>{selectedStation.stationCode} - {selectedStation.stationName ? selectedStation.stationName : selectedStation.name}</p>
                     </Popup>
                 </Marker>)
         }
@@ -178,6 +206,7 @@ const Map = ({trains, userLocation}) => {
             )}
             <TrainMarkers/>
             <UserLocationMarker/>
+            <SelectedStationMarker/>
         </MapContainer>
      </>
     );

--- a/train-tracker/src/Map.js
+++ b/train-tracker/src/Map.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from "react";
 import { MapContainer, TileLayer, Marker, Popup, GeoJSON } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
-import { APIInstance } from "./AmtrakAPI";
 import L from "leaflet";
 import { IoTrainOutline } from "react-icons/io5";
+import { FaLocationDot } from "react-icons/fa6";
 import { renderToString } from "react-dom/server";
 import './styles/Map.css';
 
@@ -20,7 +20,7 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
-const Map = ({trains}) => {
+const Map = ({trains, userLocation}) => {
     const [railLines, setRailLines] = useState(null);
     const [stations, setStations] = useState(null);
     // const [trains, setTrains] = useState([]);
@@ -93,8 +93,33 @@ const Map = ({trains}) => {
         </div>
     );
 
+    const UserLocationIcon = () => (
+        <div className="custom-icon-container" style={{ color: "red" }}>
+            <FaLocationDot size={20} />
+        </div>
+    );
+
+    function UserLocationMarker(){
+        if (userLocation){
+            return (
+                <Marker
+                    key={'userLocation'}
+                    position={[userLocation.coords.latitude, userLocation.coords.longitude]}
+                    icon={L.divIcon({
+                        html: renderToString(<UserLocationIcon />),
+                        className: 'custom-icon',
+                        iconSize: [30, 30],
+                        iconAnchor: [15, 15]
+                    })}>
+
+                    <Popup>
+                        <p>Your location.</p>
+                    </Popup>
+                </Marker>)
+        }
+    }
+
     function TrainMarkers() { 
-        console.log(trains);
         if(trains.length !== 0){
             return(
                 <div>
@@ -152,6 +177,7 @@ const Map = ({trains}) => {
                 />
             )}
             <TrainMarkers/>
+            <UserLocationMarker/>
         </MapContainer>
      </>
     );

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -1,14 +1,13 @@
 import './styles/Search.css';
-import {useState, useEffect} from 'react'
+import {useState} from 'react'
 
 import { IoSearch } from "react-icons/io5";
 import { MdClear } from "react-icons/md";
 import { MdFavoriteBorder } from "react-icons/md";
 import { setToCache } from './LocalCache';
 
-function Search({searchFun, routes, stations, setSelectedStation, selectedStation}){
+function Search({searchFun, routes, stations, setSelectedStation, selectedStation, selectedRoute, setSelectedRoute}){
     const [selectedNumber, setSelectedNumber] = useState("");
-    const [selectedRoute, setSelectedRoute] = useState("");
     const [upcoming, setUpcoming] = useState(false);
     const [fromStation, setFromStation] = useState("");
     const [toStation, setToStation] = useState("");
@@ -27,10 +26,6 @@ function Search({searchFun, routes, stations, setSelectedStation, selectedStatio
         event.preventDefault();
         searchFun(selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
     }
-
-    useEffect(()=>{
-        searchFun(selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
-    }, [selectedStation]);
 
     const clearSearch = () => {
         setSelectedNumber("");

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -1,22 +1,21 @@
 import './styles/Search.css';
-import {useState} from 'react'
+import {useState, useEffect} from 'react'
 
 import { IoSearch } from "react-icons/io5";
 import { MdClear } from "react-icons/md";
 import { MdFavoriteBorder } from "react-icons/md";
 import { setToCache } from './LocalCache';
 
-function Search({searchFun, routes, stations}){
+function Search({searchFun, routes, stations, setSelectedStation, selectedStation}){
     const [selectedNumber, setSelectedNumber] = useState("");
     const [selectedRoute, setSelectedRoute] = useState("");
-    const [selectedStation, setSelectedStation] = useState("");
     const [upcoming, setUpcoming] = useState(false);
     const [fromStation, setFromStation] = useState("");
     const [toStation, setToStation] = useState("");
 
     function handleNumber(e){ setSelectedNumber(e.target.value); }
     function handleRoute(e){ setSelectedRoute(e.target.value); }
-    function handleStation(e){ setSelectedStation(e.target.value); }
+    function handleStation(e){ setSelectedStation(e.target.value)}
     function handleUpcoming(e){ setUpcoming(e.target.checked); }
     function handleFromStation(e){ setFromStation(e.target.value); }
     function handleToStation(e){ setToStation(e.target.value); }
@@ -28,6 +27,10 @@ function Search({searchFun, routes, stations}){
         event.preventDefault();
         searchFun(selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
     }
+
+    useEffect(()=>{
+        searchFun(selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
+    }, [selectedStation]);
 
     const clearSearch = () => {
         setSelectedNumber("");

--- a/train-tracker/src/functionality/app.js
+++ b/train-tracker/src/functionality/app.js
@@ -27,6 +27,32 @@ export function filterTrains(allTrains, selectedNumber, selectedRoute, selectedS
     return trains;
 }
 
+export function getClosestStation(stations, userLocation){
+    let userLat = userLocation.coords.latitude;
+    let userLon = userLocation.coords.longitude;
+    let minDistance = calculateDistance(stations[0].lat, userLat, stations[0].lon, userLon);
+    let minStation = stations[0];
+    stations.forEach((station) => {
+        let distance = calculateDistance(station.lat, userLat, station.lon, userLon);
+        if (distance < minDistance){
+            minDistance = distance;
+            minStation = station;
+        }
+    });
+    return minStation;
+}
+
+export function convertStationCodeToStation(allStations, stationCode){
+    let matchingStations = allStations.filter((station) => {
+        return station.stationCode === stationCode;
+    });
+    return matchingStations[0];
+}
+
+function calculateDistance(lat1, lat2, lon1, lon2){
+    return (Math.sqrt(Math.pow(lat2-lat1, 2) + Math.pow(lon2-lon1, 2)));
+}
+
 function sortTrains(trains, sortingCriteria){
     return trains.sort(sortingCriteria);
 }


### PR DESCRIPTION
This PR:
- uses the geolocation API to get the user's position
- shows the user position on the map
- shows the currently selected station on the map
- finds the closest station to the user if location is provided, and autofills the search by station field with that station upon initialization

Here is what the icons look like on the map:
![image](https://github.com/user-attachments/assets/6d9565bc-1a02-46cd-9cdf-f10bf22d91b5)

I had to move some state around (up) as part of this PR. I also wanted the app to show the trains going through the closest station upon load, however to do so I had to revert the selected station to being responsive. I am not sure this makes sense from a user perspective, and I can change it back and just skip the auto-load. *Edit: removed this part*

I also added route highlighting as part of this PR. When a user selects a route, it will be highlighted on the map.

![image](https://github.com/user-attachments/assets/437b80d5-d954-4610-b97d-86bc3e28d6ba)
