### PR TITLE
Search carries over between pages

### DIFF
--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -14,7 +14,7 @@ import { IoHomeOutline } from "react-icons/io5";
 import { FaMapLocationDot } from "react-icons/fa6";
 import { IoTrainOutline } from "react-icons/io5";
 
-import {convertStationCodeToStation, getClosestStation} from './functionality/app';
+import { convertStationCodeToStation, getClosestStation, setProp} from './functionality/app';
 import { filterTrains } from './functionality/app';
 
 function App() {
@@ -24,10 +24,8 @@ function App() {
     const [refreshPopup, setRefreshPopup] = useState(false);
 
     const [userLocation, setUserLocation] = useState(null);
-    const [selectedStation, setSelectedStation] = useState("");
 
-    const [searchObject,setSearchObject] = useState(new SearchObject())
-    console.log(searchObject);
+    const [searchObject,setSearchObject] = useState(new SearchObject());
 
     const [allTrains, setAllTrains] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
@@ -36,14 +34,10 @@ function App() {
 
     const [currentTrains, setCurrentTrains] = useState([]);
 
-    const [mapRoute, setMapRoute] = useState("");
-
     const searchTrains = () => {
         let trains = filterTrains(allTrains, searchObject);
 
         setCurrentTrains(trains);
-
-        setMapRoute(searchObject.selectedRoute);
     }
 
     const toggleSidebar = () => {
@@ -64,7 +58,7 @@ function App() {
             navigator.geolocation.getCurrentPosition((pos) => {
                     setUserLocation(pos);
                     if (allStations.length > 0 && pos) {
-                        setSelectedStation(getClosestStation(allStations, pos).stationCode);
+                        setSearchObject(setProp(searchObject,"station",getClosestStation(allStations, pos).stationCode));
                     }
                 },
                 (error) => console.log('error' + error));
@@ -97,12 +91,12 @@ function App() {
     />);
 
     const MapPageComponent = () => ( <MapPage
+        userLocation={userLocation}
         allRoutes={allRoutes}
         allStations={allStations}
         setRefresh={setRefreshState}
         currentTrains={currentTrains}
         searchTrains={searchTrains}
-        mapRoute={mapRoute}
         searchObject={searchObject}
         setSearchObject={setSearchObject}
     />);

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -37,9 +37,12 @@ function App() {
 
     const searchTrains = () => {
         let trains = filterTrains(allTrains, searchObject);
-
         setCurrentTrains(trains);
     }
+
+    useEffect(() => {
+        searchTrains();
+    },[searchObject]);
 
     // wait for allTrains to load & then make search
     if(isLoading){
@@ -66,9 +69,10 @@ function App() {
         if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition((pos) => {
                     setUserLocation(pos);
+                    /* not used, but keeping in case we want to reintroduce it
                     if (allStations.length > 0 && pos) {
                         setSearchObject(setProp(searchObject,"station",getClosestStation(allStations, pos).stationCode));
-                    }
+                    }*/
                 },
                 (error) => console.log('error' + error));
         }
@@ -94,9 +98,8 @@ function App() {
         allStations={allStations}
         setRefresh={setRefreshState}
         currentTrains={currentTrains}
-        searchTrains={searchTrains}
-        searchObject={searchObject}
-        setSearchObject={setSearchObject}
+        globalSearchObject={searchObject}
+        setGlobalSearchObject={setSearchObject}
     />);
 
     const MapPageComponent = () => ( <MapPage
@@ -105,9 +108,8 @@ function App() {
         allStations={allStations}
         setRefresh={setRefreshState}
         currentTrains={currentTrains}
-        searchTrains={searchTrains}
-        searchObject={searchObject}
-        setSearchObject={setSearchObject}
+        globalSearchObject={searchObject}
+        setGlobalSearchObject={setSearchObject}
     />);
 
         return (

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -33,11 +33,20 @@ function App() {
     const [sidebarOpen, setSidebarOpen] = useState(false);
 
     const [currentTrains, setCurrentTrains] = useState([]);
+    const [isLoading,setIsLoading] = useState(true);
 
     const searchTrains = () => {
         let trains = filterTrains(allTrains, searchObject);
 
         setCurrentTrains(trains);
+    }
+
+    // wait for allTrains to load & then make search
+    if(isLoading){
+        if(allTrains.length > 0){
+            searchTrains();
+            setIsLoading(false);
+        }
     }
 
     const toggleSidebar = () => {

--- a/train-tracker/src/App.js
+++ b/train-tracker/src/App.js
@@ -7,6 +7,7 @@ import { Routes, Route, HashRouter, Link } from 'react-router-dom';
 import Home from './Home';
 import MapPage from './MapPage';
 import TrainPage from './TrainPage';
+import { SearchObject } from './Search';
 import { IoIosArrowDropleft } from "react-icons/io";
 import { IoIosArrowDropright } from "react-icons/io";
 import { IoHomeOutline } from "react-icons/io5";
@@ -25,6 +26,9 @@ function App() {
     const [userLocation, setUserLocation] = useState(null);
     const [selectedStation, setSelectedStation] = useState("");
 
+    const [searchObject,setSearchObject] = useState(new SearchObject())
+    console.log(searchObject);
+
     const [allTrains, setAllTrains] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
     const [allStations, setAllStations] = useState([]);
@@ -34,12 +38,12 @@ function App() {
 
     const [mapRoute, setMapRoute] = useState("");
 
-    const searchTrains = (selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation) => {
-        let trains = filterTrains(allTrains, selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
+    const searchTrains = () => {
+        let trains = filterTrains(allTrains, searchObject);
 
         setCurrentTrains(trains);
 
-        setMapRoute(selectedRoute);
+        setMapRoute(searchObject.selectedRoute);
     }
 
     const toggleSidebar = () => {
@@ -88,6 +92,8 @@ function App() {
         setRefresh={setRefreshState}
         currentTrains={currentTrains}
         searchTrains={searchTrains}
+        searchObject={searchObject}
+        setSearchObject={setSearchObject}
     />);
 
     const MapPageComponent = () => ( <MapPage
@@ -97,6 +103,8 @@ function App() {
         currentTrains={currentTrains}
         searchTrains={searchTrains}
         mapRoute={mapRoute}
+        searchObject={searchObject}
+        setSearchObject={setSearchObject}
     />);
 
         return (

--- a/train-tracker/src/Home.js
+++ b/train-tracker/src/Home.js
@@ -6,7 +6,7 @@ import TrainPopup from './TrainPopup';
 
 import { IoClose } from "react-icons/io5";
 
-function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains
+function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains, searchObject, setSearchObject
 }){
     // popup modal
     const [selectedTrain, setSelectedTrain] = useState({});
@@ -57,6 +57,8 @@ function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains
                 stations = {getStationOptions()}
                 searchFun = {searchTrains}
                 setRefreshState={setRefresh}
+                searchObject={searchObject}
+                setSearchObject={setSearchObject}
               />
               </div>
               <div className='app-train-list-container'>

--- a/train-tracker/src/Home.js
+++ b/train-tracker/src/Home.js
@@ -6,12 +6,11 @@ import TrainPopup from './TrainPopup';
 
 import { IoClose } from "react-icons/io5";
 
-function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains, searchObject, setSearchObject
+function Home({allRoutes, allStations, setRefresh, currentTrains, globalSearchObject, setGlobalSearchObject
 }){
     // popup modal
     const [selectedTrain, setSelectedTrain] = useState({});
     const [showModal, setShowModal] = useState(false);
-    const [showDefaultList, setDefaultList] = useState(true);
 
     const getStationOptions = () => {
         let renderedStations = allStations.map(station => {
@@ -27,11 +26,6 @@ function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains, 
         });
         renderedRoutes.unshift(<option value={""} key={""}></option>);
         return renderedRoutes;
-    }
-
-    function handleFavoriteClick(e){
-        setDefaultList(false)
-        searchTrains("", e.props.value, "", "", "", "")
     }
 
     // Modal Functions
@@ -55,10 +49,9 @@ function Home({allRoutes, allStations, setRefresh, currentTrains, searchTrains, 
               <Search className='Search'
                 routes = {getRouteOptions()}
                 stations = {getStationOptions()}
-                searchFun = {searchTrains}
                 setRefreshState={setRefresh}
-                searchObject={searchObject}
-                setSearchObject={setSearchObject}
+                globalSearchObject={globalSearchObject}
+                setGlobalSearchObject={setGlobalSearchObject}
               />
               </div>
               <div className='app-train-list-container'>

--- a/train-tracker/src/MapPage.js
+++ b/train-tracker/src/MapPage.js
@@ -41,6 +41,7 @@ function MapPage({allRoutes, allStations, userLocation, setRefresh, currentTrain
                 trains={currentTrains}
                 userLocation={userLocation}
                 selectedStation={convertStationCodeToStation(allStations, globalSearchObject.station)}
+                selectedFromStation={convertStationCodeToStation(allStations, globalSearchObject.fromStation)}
                 selectedRoute={globalSearchObject.route}
             />
               </div>

--- a/train-tracker/src/MapPage.js
+++ b/train-tracker/src/MapPage.js
@@ -5,7 +5,7 @@ import TrainMap from './TrainMap';
 
 import {convertStationCodeToStation} from './functionality/app';
 
-function MapPage({allRoutes, allStations, userLocation, setRefresh, currentTrains, searchTrains, searchObject, setSearchObject
+function MapPage({allRoutes, allStations, userLocation, setRefresh, currentTrains, globalSearchObject, setGlobalSearchObject
 }){
 
     const getStationOptions = () => {
@@ -31,19 +31,17 @@ function MapPage({allRoutes, allStations, userLocation, setRefresh, currentTrain
               <Search className='Search'
                 routes = {getRouteOptions()}
                 stations = {getStationOptions()}
-                searchFun = {searchTrains}
                 setRefreshState={setRefresh}
-                searchObject = {searchObject}
-                setSearchObject = {setSearchObject}
+                globalSearchObject = {globalSearchObject}
+                setGlobalSearchObject = {setGlobalSearchObject}
               />
               </div>
               <div className='map-container'>
               <TrainMap
                 trains={currentTrains}
                 userLocation={userLocation}
-                selectedStation={convertStationCodeToStation(allStations, searchObject.station)}
-                selectedRoute={searchObject.route}
-                searchObject = {searchObject}
+                selectedStation={convertStationCodeToStation(allStations, globalSearchObject.station)}
+                selectedRoute={globalSearchObject.route}
             />
               </div>
         </div>

--- a/train-tracker/src/MapPage.js
+++ b/train-tracker/src/MapPage.js
@@ -5,8 +5,7 @@ import TrainMap from './TrainMap';
 
 import {convertStationCodeToStation} from './functionality/app';
 
-function MapPage({allRoutes, allStations, userLocation, selectedStation, setRefresh, currentTrains, searchTrains,
-    mapRoute, searchObject, setSearchObject
+function MapPage({allRoutes, allStations, userLocation, setRefresh, currentTrains, searchTrains, searchObject, setSearchObject
 }){
 
     const getStationOptions = () => {
@@ -42,8 +41,9 @@ function MapPage({allRoutes, allStations, userLocation, selectedStation, setRefr
               <TrainMap
                 trains={currentTrains}
                 userLocation={userLocation}
-                selectedStation={convertStationCodeToStation(allStations, selectedStation)}
-                mapRoute={mapRoute}
+                selectedStation={convertStationCodeToStation(allStations, searchObject.station)}
+                selectedRoute={searchObject.route}
+                searchObject = {searchObject}
             />
               </div>
         </div>

--- a/train-tracker/src/MapPage.js
+++ b/train-tracker/src/MapPage.js
@@ -6,7 +6,7 @@ import TrainMap from './TrainMap';
 import {convertStationCodeToStation} from './functionality/app';
 
 function MapPage({allRoutes, allStations, userLocation, selectedStation, setRefresh, currentTrains, searchTrains,
-    mapRoute
+    mapRoute, searchObject, setSearchObject
 }){
 
     const getStationOptions = () => {
@@ -34,6 +34,8 @@ function MapPage({allRoutes, allStations, userLocation, selectedStation, setRefr
                 stations = {getStationOptions()}
                 searchFun = {searchTrains}
                 setRefreshState={setRefresh}
+                searchObject = {searchObject}
+                setSearchObject = {setSearchObject}
               />
               </div>
               <div className='map-container'>

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -5,8 +5,17 @@ import { IoSearch } from "react-icons/io5";
 import { MdClear, MdRefresh, MdFavoriteBorder, MdFavorite } from "react-icons/md";
 import { getLocalCache, setRouteToCache, isFavorited, removeRouteFromCache } from './LocalCache';
 
+export function SearchObject(){
+    this.number = "";
+    this.route = "";
+    this.station = "";
+    this.upcoming = false;
+    this.fromStation = "";
+    this.toStation = "";
+    this.date = "";
+}
 
-function Search({searchFun, routes, stations, setRefreshState
+function Search({searchFun, routes, stations, setRefreshState, searchObject, setSearchObject
 }){
 
     const [selectedStation, setSelectedStation] = useState("");
@@ -17,6 +26,13 @@ function Search({searchFun, routes, stations, setRefreshState
     const [toStation, setToStation] = useState("");
     const [currentRouteFavorited, setCurrentRouteFavorited] = useState(false);
 
+    // react doesn't recognize just changing an object property
+    // so we need to set it to a copy w/ the prop changed
+    function setProp(searchObj,prop,value){
+        var r = Object.assign({},searchObj)
+        r[prop] = value;
+        return r;
+    }
 
     function handleNumber(e){ setSelectedNumber(e.target.value); }
     function handleRoute(e){
@@ -72,7 +88,7 @@ function Search({searchFun, routes, stations, setRefreshState
 
     const search = (event) =>{
         event.preventDefault();
-        searchFun(selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation);
+        searchFun();
     }
 
     const clearSearch = () => {
@@ -103,7 +119,9 @@ function Search({searchFun, routes, stations, setRefreshState
                 </div>
                 <span className="select-label">
                         Train Number:
-                        <input className="select-box" value={selectedNumber} onChange={handleNumber} type="number" min='1'></input>
+                        <input className="select-box" value={searchObject.number} type="number" min='1' onChange=
+                            {e => setSearchObject(setProp(searchObject,"number",e.target.value))}
+                        />
                     </span>
                 <span className="select-label">
                         Route:

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -1,5 +1,5 @@
 import './styles/Search.css';
-import {useState} from 'react'
+import { useState, useEffect } from 'react'
 
 import { IoSearch } from "react-icons/io5";
 import { MdClear, MdRefresh, MdFavoriteBorder, MdFavorite } from "react-icons/md";
@@ -17,14 +17,20 @@ export function SearchObject(){
 
 function Search({searchFun, routes, stations, setRefreshState, searchObject, setSearchObject
 }){
-
-    const [selectedStation, setSelectedStation] = useState("");
-    const [selectedRoute, setSelectedRoute] = useState("");
-    const [selectedNumber, setSelectedNumber] = useState("");
-    const [upcoming, setUpcoming] = useState(false);
-    const [fromStation, setFromStation] = useState("");
-    const [toStation, setToStation] = useState("");
     const [currentRouteFavorited, setCurrentRouteFavorited] = useState(false);
+
+    useEffect(() => {
+        // update favorite button
+        if(isFavorited(searchObject.route)){
+            setCurrentRouteFavorited(true);
+        } else {
+            setCurrentRouteFavorited(false);
+        }
+        // clear fromStation if hidden
+        if(searchObject.fromStation !== "" && !searchObject.upcoming){
+            setSearchObject(setProp(searchObject,"fromStation",""))
+        }
+    },[searchObject]);
 
     // react doesn't recognize just changing an object property
     // so we need to set it to a copy w/ the prop changed
@@ -34,40 +40,23 @@ function Search({searchFun, routes, stations, setRefreshState, searchObject, set
         return r;
     }
 
-    function handleNumber(e){ setSelectedNumber(e.target.value); }
-    function handleRoute(e){
-        setSelectedRoute(e.target.value);
-        if (isFavorited(e.target.value)){
-            console.log(e.target.value);
-            setCurrentRouteFavorited(true);
-        }
-        else{
-            setCurrentRouteFavorited(false);
-        }
-    }
-    function handleStation(e){ setSelectedStation(e.target.value)}
-    function handleUpcoming(e){ setUpcoming(e.target.checked); }
-    function handleFromStation(e){ setFromStation(e.target.value); }
-    function handleToStation(e){ setToStation(e.target.value); }
-
     const nonFavoriteIcon = <MdFavoriteBorder style={{color:'black'}}/>;
     const favoriteIcon = <MdFavorite style={{color:'red'}}/>;
     
     function handleFavoriteSelection(e){
         if (e.target.value !== "---"){
-            setSelectedRoute(e.target.value);
-            setCurrentRouteFavorited(true);
+            setSearchObject(setProp(searchObject,"route",e.target.value))
         }   
     }
 
     function setToFavorites(){
         if(currentRouteFavorited){
-            let res = removeRouteFromCache(selectedRoute)
+            let res = removeRouteFromCache(searchObject.route)
             if(res===0){
                 setCurrentRouteFavorited(false);
             }
         } else {
-            let res = setRouteToCache(selectedRoute);
+            let res = setRouteToCache(searchObject.route);
             if(res===0){
                 setCurrentRouteFavorited(true);
             }
@@ -91,13 +80,8 @@ function Search({searchFun, routes, stations, setRefreshState, searchObject, set
         searchFun();
     }
 
-    const clearSearch = () => {
-        setSelectedNumber("");
-        setSelectedRoute("");
-        setSelectedStation("");
-        setUpcoming(false);
-        setFromStation("");
-        setToStation("");
+    const clear = () => {
+        setSearchObject(new SearchObject());
     }
 
     const refresh = () => {
@@ -115,42 +99,45 @@ function Search({searchFun, routes, stations, setRefreshState, searchObject, set
                 </label>
 
                 <div className='top-label'>
-                    Search options: 
+                    Search Options: 
                 </div>
                 <span className="select-label">
-                        Train Number:
+                        Number:
                         <input className="select-box" value={searchObject.number} type="number" min='1' onChange=
                             {e => setSearchObject(setProp(searchObject,"number",e.target.value))}
                         />
                     </span>
                 <span className="select-label">
                         Route:
-                        <select className="select-box" value={selectedRoute} onChange={handleRoute} children={routes}></select>
+                        <select className="select-box" value={searchObject.route} children={routes} onChange=
+                            {e => setSearchObject(setProp(searchObject,"route",e.target.value))}
+                        />
                         <div onClick={setToFavorites} className='form-button' style={{border:'none'}}>{currentRouteFavorited ? favoriteIcon : nonFavoriteIcon}</div>
                     </span>
-                <span className="select-label">By station: </span>
-                    <select className='select-box' value={selectedStation} onChange={handleStation} children={stations}></select>
-                    <span className="select-label">
+                <span className="select-label">{searchObject.upcoming ? "To:" : "Station:"}
+                    <select className='select-box' value={searchObject.station} children={stations} onChange=
+                        {e => setSearchObject(setProp(searchObject,"station",e.target.value))}
+                    />
+                </span>
+                <span className="select-label">
                         Upcoming trains only: 
-                        <input checked={upcoming} onChange={handleUpcoming} type="checkbox" ></input>
+                        <input checked={searchObject.upcoming} type="checkbox" onChange=
+                            {e => setSearchObject(setProp(searchObject,"upcoming",e.target.checked))}
+                        />
                     </span>
-               
-                <label className="optional-criteria-label">
-                    Optional criteria:
+                
+                {searchObject.upcoming?
                     <span className="select-label">
                         From:
-                        <select className="select-box" value={fromStation} onChange={handleFromStation} children={stations}></select>
+                        <select className="select-box" value={searchObject.fromStation} children={stations} onChange=
+                            {e => setSearchObject(setProp(searchObject,"fromStation",e.target.value))}
+                        />
                     </span>
-                    <span className="select-label">
-                        To:
-                        <select className="select-box" value={toStation} onChange={handleToStation} children={stations}></select>
-                    </span>
-                </label>
+                : <span/>}
 
                 <span className='button-container'>
                     <div onClick={search} className='form-button'>Search <IoSearch/></div>
-                    <div onClick={clearSearch} className='form-button'>Clear <MdClear/></div>
-                    
+                    <div onClick={clear} className='form-button'>Clear <MdClear/></div>
                     <div onClick={refresh} className='form-button'>Refresh <MdRefresh/></div>
                 </span>
               </form>

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -17,9 +17,15 @@ export function SearchObject(){
     this.date = "";
 }
 
-function Search({searchFun, routes, stations, setRefreshState, searchObject, setSearchObject
+function Search({routes, stations, setRefreshState, globalSearchObject, setGlobalSearchObject
 }){
+    const [searchObject,setSearchObject] = useState(new SearchObject());
     const [currentRouteFavorited, setCurrentRouteFavorited] = useState(false);
+
+    // update local search object when global search is changed
+    useEffect(() => {
+        setSearchObject(globalSearchObject);
+    },[globalSearchObject]);
 
     useEffect(() => {
         // update favorite button
@@ -69,13 +75,14 @@ function Search({searchFun, routes, stations, setRefreshState, searchObject, set
         return mapping;
     }
 
+    // search just sets global 
     const search = (event) =>{
         event.preventDefault();
-        searchFun();
+        setGlobalSearchObject(searchObject);
     }
 
     const clear = () => {
-        setSearchObject(new SearchObject());
+        setGlobalSearchObject(new SearchObject());
     }
 
     const refresh = () => {

--- a/train-tracker/src/Search.js
+++ b/train-tracker/src/Search.js
@@ -3,7 +3,9 @@ import { useState, useEffect } from 'react'
 
 import { IoSearch } from "react-icons/io5";
 import { MdClear, MdRefresh, MdFavoriteBorder, MdFavorite } from "react-icons/md";
+
 import { getLocalCache, setRouteToCache, isFavorited, removeRouteFromCache } from './LocalCache';
+import { setProp } from './functionality/app';
 
 export function SearchObject(){
     this.number = "";
@@ -31,14 +33,6 @@ function Search({searchFun, routes, stations, setRefreshState, searchObject, set
             setSearchObject(setProp(searchObject,"fromStation",""))
         }
     },[searchObject]);
-
-    // react doesn't recognize just changing an object property
-    // so we need to set it to a copy w/ the prop changed
-    function setProp(searchObj,prop,value){
-        var r = Object.assign({},searchObj)
-        r[prop] = value;
-        return r;
-    }
 
     const nonFavoriteIcon = <MdFavoriteBorder style={{color:'black'}}/>;
     const favoriteIcon = <MdFavorite style={{color:'red'}}/>;

--- a/train-tracker/src/TrainMap.js
+++ b/train-tracker/src/TrainMap.js
@@ -22,7 +22,7 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
-const TrainMap = ({trains, userLocation, selectedStation, selectedRoute}) => {
+const TrainMap = ({trains, userLocation, selectedStation, selectedFromStation, selectedRoute}) => {
     const [routes, setRoutes] = useState(null);
     const mapRef = useRef();
     
@@ -94,12 +94,12 @@ const TrainMap = ({trains, userLocation, selectedStation, selectedRoute}) => {
         }
     }
 
-    function SelectedStationMarker(){
-        if (selectedStation){
+    function SelectedStationMarker({station, name}){
+        if (station){
             return (
                 <Marker
                     key={'selectedStation'}
-                    position={[selectedStation.lat, selectedStation.lon]}
+                    position={[station.lat, station.lon]}
                     icon={L.divIcon({
                         html: renderToString(<SelectedStationIcon />),
                         className: 'custom-icon',
@@ -108,8 +108,8 @@ const TrainMap = ({trains, userLocation, selectedStation, selectedRoute}) => {
                     })}>
 
                     <Popup>
-                        <strong>Selected Station</strong>
-                        <p>{selectedStation.stationCode} - {selectedStation.stationName ? selectedStation.stationName : selectedStation.name}</p>
+                        <strong>{name}</strong>
+                        <p>{station.stationCode} - {station.stationName ? station.stationName : station.name}</p>
                     </Popup>
                 </Marker>)
         }
@@ -214,7 +214,8 @@ const TrainMap = ({trains, userLocation, selectedStation, selectedRoute}) => {
                     <RouteLines/>
                     <TrainMarkers/>
                     <UserLocationMarker/>
-                    <SelectedStationMarker/>
+                    <SelectedStationMarker station={selectedStation} name="Selected Station"/>
+                    <SelectedStationMarker station={selectedFromStation} name="From"/>
                 </MapContainer>
             </div>
         </div>

--- a/train-tracker/src/TrainMap.js
+++ b/train-tracker/src/TrainMap.js
@@ -22,7 +22,7 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
-const TrainMap = ({trains, userLocation, selectedStation, mapRoute}) => {
+const TrainMap = ({trains, userLocation, selectedStation, selectedRoute}) => {
     const [routes, setRoutes] = useState(null);
     const mapRef = useRef();
     
@@ -138,12 +138,12 @@ const TrainMap = ({trains, userLocation, selectedStation, mapRoute}) => {
                 ['Silver Service / Palmetto', 'Palmetto'],
             ]);
 
-            if (mapRoute){
-                if (name_map.has(mapRoute)){
-                    routesToDisplay = routes.features.filter((feature) => feature.properties.name === name_map.get(mapRoute));
+            if (selectedRoute){
+                if (name_map.has(selectedRoute)){
+                    routesToDisplay = routes.features.filter((feature) => feature.properties.name === name_map.get(selectedRoute));
                 }
                 else{
-                    routesToDisplay = routes.features.filter((feature) => feature.properties.name === mapRoute)
+                    routesToDisplay = routes.features.filter((feature) => feature.properties.name === selectedRoute)
                 }
                 
             }

--- a/train-tracker/src/TrainPage.js
+++ b/train-tracker/src/TrainPage.js
@@ -2,8 +2,9 @@ import './styles/TrainPage.css';
 
 import {useState, useEffect} from 'react';
 import {Link, useNavigate, useLocation} from 'react-router-dom';
-import { filterTrainPage } from './functionality/app';
+import { filterTrains } from './functionality/app';
 import TrainInfo from './TrainInfo';
+import Search, { SearchObject } from './Search';
 
 function TrainPage({allTrains}){
     const location = useLocation();
@@ -14,16 +15,18 @@ function TrainPage({allTrains}){
 
     const [selectedTrains,setSelectedTrains] = useState([]);
 
+    function findTrain(){
+        let search = new SearchObject();
+        search.number = number;
+        search.date = date;
+        let trains = filterTrains(allTrains,search);
+        setSelectedTrains(trains);
+    }
+
     // wait for allTrains to load
     if(isLoading){
         if(allTrains.length > 0){
-            let trains;
-            if (number == "all"){
-                trains = allTrains.sort((a,b) => a.number - b.number);
-            } else {
-                trains = filterTrainPage(allTrains,number,date);
-            }
-            setSelectedTrains(trains);
+            findTrain();
             setIsLoading(false);
         }
     }
@@ -47,8 +50,7 @@ function TrainPage({allTrains}){
     // updates on number or date change
     useEffect(() => {
         if(!isLoading){
-            let trains = filterTrainPage(allTrains,number,date);
-            setSelectedTrains(trains);
+            findTrain();
         } 
     },[number,date])
 

--- a/train-tracker/src/TrainPage.js
+++ b/train-tracker/src/TrainPage.js
@@ -82,9 +82,9 @@ function Tiebreaker(t){
     return(
         <div className='tiebreaker'>
             <h2>Multiple Results:</h2>
-            {t.trains.map((train) => {
+            {t.trains.map((train,index) => {
                 return(
-                    <Link to={"/trains/"+train.number+"?date="+encodeURIComponent(train.scheduledDeparture)}>
+                    <Link key={index} to={"/trains/"+train.number+"?date="+encodeURIComponent(train.scheduledDeparture)}>
                         <div>
                             <h2 className='route'>{train.routeName} (#{train.number}) - Departed {train.scheduledDeparture}</h2>
                         </div>

--- a/train-tracker/src/TrainPage.js
+++ b/train-tracker/src/TrainPage.js
@@ -1,4 +1,4 @@
-import './styles/TrainPage.css';
+import './styles/TrainList.css';
 
 import {useState, useEffect} from 'react';
 import {Link, useNavigate, useLocation} from 'react-router-dom';
@@ -79,18 +79,42 @@ function TrainPage({allTrains}){
 }
 
 function Tiebreaker(t){
+    function MakeTrain({train}){
+        const navigate = useNavigate();
+
+        const handleClick = () => {
+            navigate("/trains/"+train.number+"?date="+encodeURIComponent(train.scheduledDeparture));
+        }
+
+        return (
+            <tr onClick={handleClick} className="train-row">
+                <td>{train.routeName} #{train.number}</td>
+                <td>{train.scheduledDeparture}</td>
+                <td>{train.from}</td>
+                <td>{train.to}</td>
+            </tr>
+        );
+    }
     return(
         <div className='tiebreaker'>
-            <h2>Multiple Results:</h2>
-            {t.trains.map((train,index) => {
-                return(
-                    <Link key={index} to={"/trains/"+train.number+"?date="+encodeURIComponent(train.scheduledDeparture)}>
-                        <div>
-                            <h2 className='route'>{train.routeName} (#{train.number}) - Departed {train.scheduledDeparture}</h2>
-                        </div>
-                    </Link>
-                )
-            })}
+            <h2>Multiple Results ({t.trains.length}):</h2>
+            <div className="train-list-container">
+                <table className="train-list">
+                    <thead>
+                        <tr>
+                            <th>Train Name</th>
+                            <th>Departed At</th>
+                            <th>From</th>
+                            <th>To</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {t.trains.map((t,index) =>
+                            <MakeTrain train={t} key={index}/>
+                        )}
+                    </tbody>
+                </table>
+            </div>
         </div>
     )
 }

--- a/train-tracker/src/functionality/app.js
+++ b/train-tracker/src/functionality/app.js
@@ -1,3 +1,12 @@
+// returns a copy of SearchObject with a property changed
+// react doesn't recognize just changing an object property
+// so we need to set it to a copy w/ the prop changed
+export function setProp(searchObj,prop,value){
+    var r = Object.assign({},searchObj)
+    r[prop] = value;
+    return r;
+}
+
 export function filterTrains(allTrains, sObj) {
     let trains = allTrains ?? [];
     if (sObj.number > 0){

--- a/train-tracker/src/functionality/app.js
+++ b/train-tracker/src/functionality/app.js
@@ -1,14 +1,14 @@
-export function filterTrains(allTrains, selectedNumber, selectedRoute, selectedStation, upcoming, fromStation, toStation) {
-    let trains = allTrains;
-    if (selectedNumber > 0){
-        trains = trains.filter(t => t.number === selectedNumber)
-    } if (selectedRoute){
-        trains = trains.filter(t => t.routeName === selectedRoute)
-    } if (selectedStation){
-        trains = trains.filter((t) => (t.stations.findIndex((station) => station.stationCode === selectedStation) !== -1));
-        if (upcoming){
+export function filterTrains(allTrains, sObj) {
+    let trains = allTrains ?? [];
+    if (sObj.number > 0){
+        trains = trains.filter(t => t.number === sObj.number)
+    } if (sObj.selectedRoute){
+        trains = trains.filter(t => t.routeName === sObj.selectedRoute)
+    } if (sObj.selectedStation){
+        trains = trains.filter((t) => (t.stations.findIndex((station) => station.stationCode === sObj.selectedStation) !== -1));
+        if (sObj.upcoming){
             trains = trains.filter((t) => {
-                let station = t.stations.find((station) => station.stationCode === selectedStation);
+                let station = t.stations.find((station) => station.stationCode === sObj.selectedStation);
                 if (station.stationCode === t.from && station.hasDeparted){
                     return undefined;
                 }
@@ -17,25 +17,16 @@ export function filterTrains(allTrains, selectedNumber, selectedRoute, selectedS
                 }
             })
         }
-    } if (fromStation && toStation){
+    } if (sObj.fromStation && sObj.toStation){
         trains = trains.filter((t) =>{
-            return t.stations.findIndex((station) => station.stationCode === fromStation) < t.stations.findIndex((station) => station.stationCode === toStation);
+            return t.stations.findIndex((station) => station.stationCode === sObj.fromStation) < t.stations.findIndex((station) => station.stationCode === sObj.toStation);
         })
+    } if (sObj.date){
+        trains = trains.filter(t => t.scheduledDeparture === sObj.date)
     }
     // sort results by number (ascending)
     trains = sortTrains(trains, (a,b) => a.number - b.number);
     return trains;
-}
-
-// very lazy alternative filter for train page (will refactor later)
-export function filterTrainPage(allTrains, selectedNumber, selectedDate){
-    let trains = allTrains ?? [];
-    if(selectedNumber > 0){
-        trains = trains.filter(t => t.number === selectedNumber)
-    } if (selectedDate){
-        trains = trains.filter(t => t.scheduledDeparture === selectedDate)
-    }
-    return trains
 }
 
 export function getClosestStation(stations, userLocation){

--- a/train-tracker/src/functionality/app.js
+++ b/train-tracker/src/functionality/app.js
@@ -2,13 +2,13 @@ export function filterTrains(allTrains, sObj) {
     let trains = allTrains ?? [];
     if (sObj.number > 0){
         trains = trains.filter(t => t.number === sObj.number)
-    } if (sObj.selectedRoute){
-        trains = trains.filter(t => t.routeName === sObj.selectedRoute)
-    } if (sObj.selectedStation){
-        trains = trains.filter((t) => (t.stations.findIndex((station) => station.stationCode === sObj.selectedStation) !== -1));
+    } if (sObj.route){
+        trains = trains.filter(t => t.routeName === sObj.route)
+    } if (sObj.station){
+        trains = trains.filter((t) => (t.stations.findIndex((station) => station.stationCode === sObj.station) !== -1));
         if (sObj.upcoming){
             trains = trains.filter((t) => {
-                let station = t.stations.find((station) => station.stationCode === sObj.selectedStation);
+                let station = t.stations.find((station) => station.stationCode === sObj.station);
                 if (station.stationCode === t.from && station.hasDeparted){
                     return undefined;
                 }
@@ -17,9 +17,9 @@ export function filterTrains(allTrains, sObj) {
                 }
             })
         }
-    } if (sObj.fromStation && sObj.toStation){
+    } if (sObj.fromStation){
         trains = trains.filter((t) =>{
-            return t.stations.findIndex((station) => station.stationCode === sObj.fromStation) < t.stations.findIndex((station) => station.stationCode === sObj.toStation);
+            return t.stations.findIndex((station) => station.stationCode === sObj.fromStation) < t.stations.findIndex((station) => station.stationCode === sObj.station);
         })
     } if (sObj.date){
         trains = trains.filter(t => t.scheduledDeparture === sObj.date)

--- a/train-tracker/src/styles/TrainInfo.css
+++ b/train-tracker/src/styles/TrainInfo.css
@@ -45,7 +45,7 @@
 .train-table {
     width: 100%;
     border-collapse: collapse;
-    height: 80vh;
+    max-height: 80vh;
     margin-bottom: 30px;
     overflow: scroll;
 }

--- a/train-tracker/src/styles/TrainList.css
+++ b/train-tracker/src/styles/TrainList.css
@@ -32,7 +32,7 @@
 }
 
 .train-list tbody tr:hover {
-    border: 5px solid #97ccf0;
+    background-color: #97ccf0;
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
     cursor: pointer;
 }

--- a/train-tracker/src/styles/TrainPage.css
+++ b/train-tracker/src/styles/TrainPage.css
@@ -1,5 +1,0 @@
-.tiebreaker {
-    background-color: white;
-    overflow: auto; /* Enable vertical scrolling */
-    max-height: 800px; /* Set a maximum height to trigger scrolling */
-}


### PR DESCRIPTION
In this pr:
- Massive refactor introducing a search object to store all search criteria that updates when search button is pressed, this carries between to map and home page to accurate display the information being shown
- All trains now show on load, in my opinion this is more intuitive and immediately shows what the program is meant to do
- Simplified search bar 
![image](https://github.com/user-attachments/assets/5cb6367b-24d2-4486-8238-996432b6fb6d)
- Killed the "toStation" part of the search in favor of upcoming trains boolean controlling the to/from part of the search
- Both selected stations show on map
![image](https://github.com/user-attachments/assets/7f769f1c-966c-4e35-9f5f-6bdef1b74a3a)
- fixed user location not showing on map
- fixes to css styling that's really bothered me, for example the border around hovered train on train table that seemed to mess up the width of everything
![image](https://github.com/user-attachments/assets/540697d5-2513-47b6-989b-3985af560de4)
